### PR TITLE
 Enable building with the GHC Wasm backend 

### DIFF
--- a/cabal.config
+++ b/cabal.config
@@ -1,1 +1,0 @@
-compiler: ghcjs

--- a/cabal.project
+++ b/cabal.project
@@ -1,2 +1,28 @@
 packages: ./.
-          ./example
+
+if arch(javascript)
+  packages: ./example
+
+if arch(wasm32)
+  -- older versions of `time` don't build on WASM
+  -- https://github.com/haskellari/time-compat/issues/37
+  constraints: time installed
+  allow-newer: time
+
+  -- waiting for release
+  -- https://github.com/dmjio/miso/pull/752
+  source-repository-package
+    type: git
+    location: https://github.com/dmjio/miso
+    tag: e411f3e2872465f37eb53b6de4542010a105b53a
+
+  -- Wasm support
+  https://github.com/diagrams/diagrams-lib/pull/372
+  source-repository-package
+    type: git
+    location: https://github.com/georgefst/diagrams-lib
+    tag: 19d9ebeb22385a7674ea7bec6856dc130b73350f
+
+  -- default global Wasm config adds `:override` for `head.hackage` - often not what we want
+  -- https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta/-/issues/9#note_553150
+  active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org

--- a/diagrams-miso.cabal
+++ b/diagrams-miso.cabal
@@ -24,15 +24,15 @@ Library
                        Graphics.Rendering.Miso
   Hs-source-dirs:      src
   Build-depends:       aeson
-                     , base                 >= 4.9   && < 4.10
-                     , mtl                  >= 1     && < 2.3
+                     , base                 >= 4.11   && < 4.21
+                     , mtl                  >= 1     && < 2.4
                      , colour >= 2.3.2 && < 2.4
-                     , diagrams-core        >= 1.4   && < 1.5
+                     , diagrams-core        >= 1.4   && < 1.6
                      , diagrams-lib         >= 1.4   && < 1.5
-                     , monoid-extras        >= 0.3   && < 0.5
+                     , monoid-extras        >= 0.3   && < 0.7
                      , miso                 >= 0.8
-                     , containers           >= 0.3   && < 0.6
-                     , lens                 >= 4.15   && < 4.16
+                     , containers           >= 0.3   && < 0.8
+                     , lens                 >= 4.15   && < 5.4
 
   Ghc-options:         -Wall
 

--- a/src/Diagrams/Backend/Miso.hs
+++ b/src/Diagrams/Backend/Miso.hs
@@ -59,7 +59,7 @@ import           Diagrams.Core.Types (Annotation (..))
 import           Diagrams.Prelude hiding (Attribute, size, view, local, text, query)
 import           Diagrams.TwoD.Adjust (adjustDia2D)
 import           Diagrams.TwoD.Text (Text(..))
-import           Miso hiding (Options, view, Result, onMouseDown, onMouseUp)
+import           Miso hiding (Options, view, Result, onMouseDown, onMouseUp, Node)
 import           Miso.String (MisoString, ms)
 
 import           Graphics.Rendering.Miso (RenderM)
@@ -78,9 +78,10 @@ type B = MisoSvg
 type instance V MisoSvg = V2
 type instance N MisoSvg = Double
 
+instance Semigroup (Render MisoSvg V2 Double) where
+  Render r1 <> Render r2_ = Render $ mappend r1 r2_
 instance Monoid (Render MisoSvg V2 Double) where
   mempty = Render mempty
-  Render r1 `mappend` Render r2_ = Render $ mappend r1 r2_
 
 instance Backend MisoSvg V2 Double where
   newtype Render  MisoSvg V2 Double = Render RenderM

--- a/src/Graphics/Rendering/Miso.hs
+++ b/src/Graphics/Rendering/Miso.hs
@@ -51,9 +51,10 @@ data Element = Element
 
 type RenderM = Reader (Style V2 Double) [Element]
 
+instance Semigroup RenderM where
+  a <> b = mappend <$> a <*> b
 instance Monoid RenderM where
   mempty = return []
-  mappend a b = mappend <$> a <*> b
 
 type AttributeValue = String
 


### PR DESCRIPTION
Based on #5.

Builds with, for example, `nix shell gitlab:haskell-wasm/ghc-wasm-meta?rev=56dfe2478cae35ded335261c854bb8b2a5e7f4d2#all_9_10 -c wasm32-wasi-cabal build all`.

I've been using this library successfully with Wasm.